### PR TITLE
feat: extended registry metadata response

### DIFF
--- a/packages/public-api/src/website/router.test.ts
+++ b/packages/public-api/src/website/router.test.ts
@@ -1,4 +1,4 @@
-import { internalApi, WebPage, WebPagePackage } from '@gradejs-public/shared';
+import { internalApi, PackageMetadata, WebPage, WebPagePackage } from '@gradejs-public/shared';
 import {
   createSupertestApi,
   useDatabaseConnection,
@@ -67,13 +67,26 @@ describe('routes / website', () => {
       packageVersionRange: '17.0.2',
     });
 
+    const packageMetadataInsert = await getRepository(PackageMetadata).insert({
+      name: 'react',
+      latestVersion: '18.0.0',
+      monthlyDownloads: 100,
+      updateSeq: 5,
+      license: 'MIT',
+    });
+
     const response = await api.get(`/website/${hostname}`).expect(200);
 
     expect(fetchUrlPackagesMock).toHaveBeenCalledTimes(0);
     expect(response.body).toMatchObject({
       data: {
         webpages: webpageInsert.generatedMaps,
-        packages: packageInsert.generatedMaps,
+        packages: [
+          {
+            ...packageInsert.generatedMaps[0],
+            registryMetadata: packageMetadataInsert.generatedMaps[0],
+          },
+        ],
       },
     });
   });

--- a/packages/public-api/src/website/service.ts
+++ b/packages/public-api/src/website/service.ts
@@ -56,7 +56,10 @@ export function getWebPagesByHostname(hostname: string) {
 }
 
 export function getPackagesByHostname(hostname: string) {
-  return getRepository(WebPagePackage).find({ hostname });
+  return getRepository(WebPagePackage).find({
+    relations: ['registryMetadata'],
+    where: { hostname },
+  });
 }
 
 function mapInternalWebsiteStatus(status: internalApi.WebsiteStatus) {

--- a/packages/shared/src/database/entities/packageMetadata.ts
+++ b/packages/shared/src/database/entities/packageMetadata.ts
@@ -13,6 +13,21 @@ export class PackageMetadata extends BaseEntity {
   latestVersion!: string;
 
   @Column()
+  monthlyDownloads!: number;
+
+  @Column()
+  description?: string;
+
+  @Column()
+  homepageUrl?: string;
+
+  @Column()
+  repositoryUrl?: string;
+
+  @Column()
+  license?: string;
+
+  @Column()
   updateSeq!: number;
 
   @Column()

--- a/packages/shared/src/database/entities/webPagePackage.ts
+++ b/packages/shared/src/database/entities/webPagePackage.ts
@@ -6,7 +6,10 @@ import {
   BaseEntity,
   CreateDateColumn,
   UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
 } from 'typeorm';
+import { PackageMetadata } from './packageMetadata';
 
 export type WebPagePackageMetadata = {
   approximateByteSize?: number;
@@ -41,4 +44,8 @@ export class WebPagePackage extends BaseEntity {
 
   @CreateDateColumn()
   createdAt!: Date;
+
+  @ManyToOne(() => PackageMetadata)
+  @JoinColumn({ name: 'package_name', referencedColumnName: 'name' })
+  registryMetadata?: PackageMetadata;
 }

--- a/packages/shared/src/database/migrations/1653653200864-ExtendedPackageMetadata.ts
+++ b/packages/shared/src/database/migrations/1653653200864-ExtendedPackageMetadata.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ExtendedPackageMetadata1653653200864 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      alter table "package_metadata" add column "monthly_downloads" int;
+      alter table "package_metadata" add column "description" text;
+      alter table "package_metadata" add column "homepage_url" text;
+      alter table "package_metadata" add column "repository_url" text;
+      alter table "package_metadata" add column "license" text;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      alter table "package_metadata" drop column "monthly_downloads";
+      alter table "package_metadata" drop column "description";
+      alter table "package_metadata" drop column "homepage_url";
+      alter table "package_metadata" drop column "repository_url";
+      alter table "package_metadata" drop column "license";
+    `);
+  }
+}

--- a/packages/shared/src/internalApi/api.ts
+++ b/packages/shared/src/internalApi/api.ts
@@ -59,18 +59,18 @@ export async function fetchPackageIndex(offset = 0, limit = 0) {
 }
 
 export async function requestPackageIndexing(payload: PackageIndexRequest) {
-  return fetchEndpoint<boolean>('POST', '/package/index?mode=append', payload);
+  return fetchEndpoint<boolean>('PATCH', '/package/index', payload);
 }
 
 export async function fetchEndpoint<T>(
-  method: 'GET' | 'POST',
+  method: 'GET' | 'POST' | 'PATCH',
   endpoint: string,
   data?: Record<string, unknown>
 ) {
   const requestUrl = new URL(endpoint, getInternalApiOrigin());
   const requestInit: RequestInit = { method };
 
-  if (method === 'POST') {
+  if (method === 'POST' || method === 'PATCH') {
     requestInit.headers = { 'Content-Type': 'application/json' };
     requestInit.body = JSON.stringify(data);
   } else if (method === 'GET' && data) {

--- a/packages/shared/src/internalApi/api.ts
+++ b/packages/shared/src/internalApi/api.ts
@@ -31,6 +31,12 @@ export interface Package {
   latestVersion: string;
 }
 
+export interface PackageIndexRequest {
+  name: string;
+  versions: string[];
+  [key: string]: unknown;
+}
+
 type Paginaton = {
   offset: number;
   limit: number;
@@ -52,10 +58,8 @@ export async function fetchPackageIndex(offset = 0, limit = 0) {
   });
 }
 
-export async function requestPackageIndexing(packagesToIndex: string[]) {
-  return fetchEndpoint<boolean>('POST', '/package/index', {
-    packages: packagesToIndex,
-  });
+export async function requestPackageIndexing(payload: PackageIndexRequest) {
+  return fetchEndpoint<boolean>('POST', '/package/index?mode=append', payload);
 }
 
 export async function fetchEndpoint<T>(

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -6,7 +6,12 @@ import {
   Env,
 } from '@gradejs-public/shared';
 
-checkRequiredEnvironmentVariables([Env.AwsRegion, Env.DatabaseUrl, Env.SqsWorkerQueueUrl]);
+checkRequiredEnvironmentVariables([
+  Env.AwsRegion,
+  Env.DatabaseUrl,
+  Env.InternalApiOrigin,
+  Env.SqsWorkerQueueUrl,
+]);
 
 const port = getPort(8080);
 

--- a/packages/worker/src/npmRegistry/api.test.ts
+++ b/packages/worker/src/npmRegistry/api.test.ts
@@ -4,13 +4,17 @@ import { fetchPackageMetadata, fetchPackageDownloads } from './api';
 // Requesting the NPM registry may cause some delays
 jest.setTimeout(30000);
 
-describe('npmRegistry / api', () => {
+// TODO: The replicate npm registry may be down sometimes and these tests are flaky
+describe.skip('npmRegistry / api', () => {
   it('fetchPackageMetadata', async () => {
     const metadata = await fetchPackageMetadata('react');
 
     expect(semver.gte(metadata.latestVersion, '18.0.0')).toBeTruthy();
+    expect(metadata.repositoryUrl).toEqual('https://github.com/facebook/react');
+    expect(metadata.homepageUrl).toEqual('https://reactjs.org/');
+    expect(metadata.description).toContain('React');
+    expect(metadata.license).toEqual('MIT');
     expect(metadata.versionList).toContain('17.0.0');
-    expect(metadata.versionList).not.toContain('18.0.0-alpha-00ced1e2b-20211102');
     expect(metadata.updatedAt > new Date(2010, 1, 1)).toBeTruthy();
     expect(metadata.updateSeq > 100_000).toBeTruthy();
   });

--- a/packages/worker/src/npmRegistry/api.test.ts
+++ b/packages/worker/src/npmRegistry/api.test.ts
@@ -1,5 +1,5 @@
 import semver from 'semver';
-import { fetchPackageMetadata, fetchPackageDownloads } from './api';
+import { fetchPackageMetadata, fetchPackageDownloads, getRepositoryUrl } from './api';
 
 // Requesting the NPM registry may cause some delays
 jest.setTimeout(30000);
@@ -23,5 +23,18 @@ describe.skip('npmRegistry / api', () => {
     const stats = await fetchPackageDownloads('object-assign');
 
     expect(stats.downloads).toBeGreaterThan(1_000_000);
+  });
+});
+
+describe('npmRegistry / getRepositoryUrl', () => {
+  it.each([
+    ['git+https://github.com/facebook/react.git', 'https://github.com/facebook/react'],
+    ['https://github.com/facebook/react', 'https://github.com/facebook/react'],
+    ['git://github.com/auth0/lock', 'https://github.com/auth0/lock'],
+    ['github:foo/bar', 'https://github.com/foo/bar'],
+    ['gitlab:foo/bar', 'https://gitlab.com/foo/bar'],
+    ['bitbucket:foo/bar', 'https://bitbucket.org/foo/bar'],
+  ])('should give valid url', (target, result) => {
+    expect(getRepositoryUrl(target)).toEqual(result);
   });
 });

--- a/packages/worker/src/npmRegistry/api.ts
+++ b/packages/worker/src/npmRegistry/api.ts
@@ -103,7 +103,7 @@ function isValidUrl(maybeUrl: string) {
   return url.protocol === 'http:' || url.protocol === 'https:';
 }
 
-function getRepositoryUrl(repository?: string) {
+export function getRepositoryUrl(repository?: string) {
   let url;
 
   if (!repository) {
@@ -111,13 +111,13 @@ function getRepositoryUrl(repository?: string) {
   }
 
   // (git+)https://github.com/facebook/react(.git)
-  if ((url = repository.match(/^(|git\+)(https?:.*?)(|.git)$/))) {
-    return url[2];
+  if ((url = repository.match(/^(?:git\+)?(https?:.*?)(?:\.git)?$/))) {
+    return url[1];
   }
 
   // git://github.com/auth0/lock(.git)
-  if ((url = repository.match(/^git:\/\/(.*?)(|.git)$/))) {
-    return `https://${url[2]}`;
+  if ((url = repository.match(/^git:\/\/(.*?)(?:.git)?$/))) {
+    return `https://${url[1]}`;
   }
 
   // github:user/repo

--- a/packages/worker/src/npmRegistry/api.ts
+++ b/packages/worker/src/npmRegistry/api.ts
@@ -7,6 +7,16 @@ const REGISTRY_URL = 'https://replicate.npmjs.com';
 const NPM_API_ORIGIN = 'https://api.npmjs.org';
 
 type DocumentScope = {
+  description?: string;
+  license?: string;
+  homepage?: string;
+  repository?:
+    | string
+    | {
+        type?: string;
+        directory?: string;
+        url?: string;
+      };
   time: {
     modified: string;
     created: string;
@@ -24,15 +34,35 @@ export async function fetchPackageMetadata(name: string) {
   const document = await registry.get(name, { local_seq: true });
   const versionList = Object.keys(document.versions);
 
+  let homepageUrl, repositoryUrl;
+
+  if (document.homepage && isValidUrl(document.homepage)) {
+    homepageUrl = document.homepage;
+  }
+
+  if (typeof document.repository === 'string') {
+    repositoryUrl = getRepositoryUrl(document.repository);
+  }
+
+  if (typeof document.repository === 'object') {
+    repositoryUrl = getRepositoryUrl(document.repository.url);
+  }
+
+  // TODO: reconsider this part, since currently the internal API filters version by itself
   // Filter out intermediate versions such as X.Y.Z-dev-0 and include only stable ones
-  const versionListFiltered = versionList.filter(
-    (item: string) => item.search(/^(\d+\.)?(\d+\.)?(\d+)$/) > -1
-  );
+  // const versionListFiltered = versionList.filter(
+  //   (item: string) => item.search(/^(\d+\.)?(\d+\.)?(\d+)$/) > -1
+  // );
+
   return {
+    description: document.description || undefined,
+    license: document.license || undefined,
+    homepageUrl,
+    repositoryUrl,
     updateSeq: Number(document._local_seq),
     updatedAt: new Date(document.time.modified),
     latestVersion: document['dist-tags'].latest,
-    versionList: versionListFiltered,
+    versionList,
   };
 }
 
@@ -59,4 +89,52 @@ export async function fetchPackageStatsAndMetadata(name: string) {
     ...stats,
     ...metadata,
   };
+}
+
+function isValidUrl(maybeUrl: string) {
+  let url;
+
+  try {
+    url = new URL(maybeUrl);
+  } catch (_) {
+    return false;
+  }
+
+  return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+function getRepositoryUrl(repository?: string) {
+  let url;
+
+  if (!repository) {
+    return;
+  }
+
+  // (git+)https://github.com/facebook/react(.git)
+  if ((url = repository.match(/^(|git\+)(https?:.*?)(|.git)$/))) {
+    return url[2];
+  }
+
+  // git://github.com/auth0/lock(.git)
+  if ((url = repository.match(/^git:\/\/(.*?)(|.git)$/))) {
+    return `https://${url[2]}`;
+  }
+
+  // github:user/repo
+  if ((url = repository.match(/^(\w+):([\w_\-\.]+)\/([\w_\-\.]+)$/))) {
+    switch (url[1]) {
+      case 'github':
+        return `https://github.com/${url[2]}/${url[3]}`;
+
+      case 'gitlab':
+        return `https://gitlab.com/${url[2]}/${url[3]}`;
+
+      case 'bitbucket':
+        return `https://bitbucket.org/${url[2]}/${url[3]}`;
+
+      default:
+    }
+  }
+
+  return repository;
 }

--- a/packages/worker/src/npmRegistry/api.ts
+++ b/packages/worker/src/npmRegistry/api.ts
@@ -104,33 +104,36 @@ function isValidUrl(maybeUrl: string) {
 }
 
 export function getRepositoryUrl(repository?: string) {
-  let url;
-
   if (!repository) {
     return;
   }
 
+  let urlMatch;
+
   // (git+)https://github.com/facebook/react(.git)
-  if ((url = repository.match(/^(?:git\+)?(https?:.*?)(?:\.git)?$/))) {
-    return url[1];
+  if ((urlMatch = repository.match(/^(?:git\+)?(https?:.*?)(?:\.git)?$/))) {
+    const [, repoUrl] = urlMatch;
+    return repoUrl;
   }
 
   // git://github.com/auth0/lock(.git)
-  if ((url = repository.match(/^git:\/\/(.*?)(?:.git)?$/))) {
-    return `https://${url[1]}`;
+  if ((urlMatch = repository.match(/^git:\/\/(.*?)(?:.git)?$/))) {
+    const [, repoUrl] = urlMatch;
+    return `https://${repoUrl}`;
   }
 
   // github:user/repo
-  if ((url = repository.match(/^(\w+):([\w_\-\.]+)\/([\w_\-\.]+)$/))) {
-    switch (url[1]) {
+  if ((urlMatch = repository.match(/^(\w+):([\w_\-\.]+)\/([\w_\-\.]+)$/))) {
+    const [, repoType, repoUser, repoName] = urlMatch;
+    switch (repoType) {
       case 'github':
-        return `https://github.com/${url[2]}/${url[3]}`;
+        return `https://github.com/${repoUser}/${repoName}`;
 
       case 'gitlab':
-        return `https://gitlab.com/${url[2]}/${url[3]}`;
+        return `https://gitlab.com/${repoUser}/${repoName}`;
 
       case 'bitbucket':
-        return `https://bitbucket.org/${url[2]}/${url[3]}`;
+        return `https://bitbucket.org/${repoUser}/${repoName}`;
 
       default:
     }

--- a/packages/worker/src/tasks/syncPackageIndexBatch.test.ts
+++ b/packages/worker/src/tasks/syncPackageIndexBatch.test.ts
@@ -36,10 +36,10 @@ describe('task / syncPackageIndexBatch', () => {
 
     expect(npmApisFetchMock).toHaveBeenCalledTimes(1);
     expect(requestPackageIndexingMock).toHaveBeenCalledTimes(1);
-    expect(requestPackageIndexingMock).toHaveBeenCalledWith([
-      'any-fake-package@1.0.1',
-      'any-fake-package@1.1.0',
-    ]);
+    expect(requestPackageIndexingMock).toHaveBeenCalledWith({
+      name: 'any-fake-package',
+      versions: ['0.1.0', '1.0.0', '1.0.1', '1.1.0'],
+    });
 
     const savedPackage = await getRepository(PackageMetadata).findOne({ name: mockedPackage.name });
 
@@ -77,12 +77,12 @@ describe('task / syncPackageIndexBatch', () => {
     ]);
 
     expect(npmApisFetchMock).toHaveBeenCalledTimes(1);
-    expect(requestPackageIndexingMock).toHaveBeenCalledTimes(0);
+    expect(requestPackageIndexingMock).toHaveBeenCalledTimes(1);
 
     const updatedPackage = await getRepository(PackageMetadata).findOne({
       name: savedPackage.name,
     });
 
-    expect(savedPackage).toMatchObject(updatedPackage as any);
+    expect(updatedPackage).toMatchObject(savedPackage);
   });
 });


### PR DESCRIPTION
- More useful fields for the package metadata entity
- Updated process for the package sync
- Skip flaky tests with the NPM registry