### PR TITLE
fix: add text overflow to tag links,

### DIFF
--- a/packages/web/src/components/ui/PackagePreview/PackagePreview.module.scss
+++ b/packages/web/src/components/ui/PackagePreview/PackagePreview.module.scss
@@ -347,21 +347,33 @@
 }
 
 .tags {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(5, auto) 53px;
+  grid-gap: 18px;
+  justify-content: start;
   align-items: center;
+  padding-right: 24px;
 
-  & > * + * {
-    margin-left: 24px;
+  @include lg {
+    grid-template-columns: repeat(4, auto) 53px;
+  }
 
-    @include mobile-and-tablet {
-      margin-left: 18px;
-    }
+  @include sm {
+    grid-template-columns: repeat(3, auto) 50px;
+    padding-right: 18px;
+  }
+
+  @include mobile {
+    grid-template-columns: repeat(2, auto) 50px;
   }
 }
 
 .tag {
   font-weight: 500;
   transition: opacity $transition-duration $transition-timing-function;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   &:hover {
     opacity: 0.6;

--- a/packages/web/src/components/ui/PackagePreview/PackagePreview.stories.tsx
+++ b/packages/web/src/components/ui/PackagePreview/PackagePreview.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import PackagePreview from './PackagePreview';
 import { PackagePreviewSkeleton } from './PackagePreviewSkeleton';
 import { IdentifiedPackage } from 'store/selectors/websiteResults';
+import Container from '../Container/Container';
 
 export default {
   title: 'Interface / PackagePreview',
@@ -100,4 +101,16 @@ export const OpenedLoading: ComponentStory<typeof PackagePreview> = () => (
 
 export const Opened: ComponentStory<typeof PackagePreview> = () => (
   <PackagePreview pkg={pkg} opened />
+);
+
+export const InsideContainerClosed: ComponentStory<typeof PackagePreview> = () => (
+  <Container>
+    <PackagePreview pkg={pkg} />
+  </Container>
+);
+
+export const InsideContainerOpened: ComponentStory<typeof PackagePreview> = () => (
+  <Container>
+    <PackagePreview pkg={pkg} opened />
+  </Container>
 );


### PR DESCRIPTION
Improve spacing and collapsing for them

Before:
![image](https://user-images.githubusercontent.com/2999208/192889264-71b13983-640d-47aa-b934-cdd7179d113e.png)

After:
![after](https://user-images.githubusercontent.com/2999208/192888813-4133124d-ddd8-483d-ba4b-fa2323948bfc.png)
