### PR TITLE
feat: limit maximum avatar items in avatar group 

### DIFF
--- a/packages/web/src/components/ui/Avatar/Avatar.module.scss
+++ b/packages/web/src/components/ui/Avatar/Avatar.module.scss
@@ -2,8 +2,8 @@
 @import '~styles/responsive.scss';
 
 .avatarItem {
-  width: 32px;
-  height: 32px;
+  width: 36px;
+  height: 36px;
   border: 2px solid $white;
   border-radius: 50%;
   overflow: hidden;
@@ -37,4 +37,15 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.additionalAvatars {
+  font-weight: 500;
+  font-size: 14px;
+  background: $blue-additional;
+  color: $blue-accent;
+
+  @include xxl {
+    font-size: 16px;
+  }
 }

--- a/packages/web/src/components/ui/Avatar/Avatar.tsx
+++ b/packages/web/src/components/ui/Avatar/Avatar.tsx
@@ -21,7 +21,7 @@ const Avatar = ({ variant, src, altAsTooltip = false, alt = '', children }: Prop
   return (
     <>
       <div className={clsx(styles.avatarItem, variant && styles[variant])} ref={setTriggerRef}>
-        {src && <img src={src} className={styles.avatarImage} alt={alt} />}
+        {src && <img src={src} className={styles.avatarImage} alt={alt} loading='lazy' />}
         {children}
       </div>
       {altAsTooltip && visible && (

--- a/packages/web/src/components/ui/Avatar/Avatar.tsx
+++ b/packages/web/src/components/ui/Avatar/Avatar.tsx
@@ -2,23 +2,27 @@ import React from 'react';
 import styles from './Avatar.module.scss';
 import stylesTooltip from '../Tooltip/Tooltip.module.scss'; // TODO: is it ok to reference external styles?
 import { Config, usePopperTooltip } from 'react-popper-tooltip';
+import clsx from 'clsx';
 
 type Props = {
-  src: string;
+  variant?: 'additionalAvatars';
+  src?: string;
   altAsTooltip?: boolean;
   alt?: string;
+  children?: React.ReactNode;
 };
 
 const tooltipOptions: Config = { placement: 'top-end', offset: [20, 13] };
 
-const Avatar = ({ src, altAsTooltip = false, alt = '' }: Props) => {
+const Avatar = ({ variant, src, altAsTooltip = false, alt = '', children }: Props) => {
   const { getArrowProps, getTooltipProps, setTooltipRef, setTriggerRef, visible } =
     usePopperTooltip(tooltipOptions);
 
   return (
     <>
-      <div className={styles.avatarItem} ref={setTriggerRef}>
-        <img src={src} className={styles.avatarImage} alt={alt} />
+      <div className={clsx(styles.avatarItem, variant && styles[variant])} ref={setTriggerRef}>
+        {src && <img src={src} className={styles.avatarImage} alt={alt} />}
+        {children}
       </div>
       {altAsTooltip && visible && (
         <div

--- a/packages/web/src/components/ui/AvatarGroup/AvatarGroup.stories.tsx
+++ b/packages/web/src/components/ui/AvatarGroup/AvatarGroup.stories.tsx
@@ -33,13 +33,3 @@ export const MoreThanMax: ComponentStory<typeof AvatarGroup> = () => (
     </AvatarGroup>
   </div>
 );
-
-export const Total: ComponentStory<typeof AvatarGroup> = () => (
-  <div style={{ display: 'flex', justifyContent: 'center' }}>
-    <AvatarGroup total={20}>
-      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
-      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
-      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
-    </AvatarGroup>
-  </div>
-);

--- a/packages/web/src/components/ui/AvatarGroup/AvatarGroup.stories.tsx
+++ b/packages/web/src/components/ui/AvatarGroup/AvatarGroup.stories.tsx
@@ -20,3 +20,26 @@ export const Primary: ComponentStory<typeof AvatarGroup> = () => (
     </AvatarGroup>
   </div>
 );
+
+export const MoreThanMax: ComponentStory<typeof AvatarGroup> = () => (
+  <div style={{ display: 'flex', justifyContent: 'center' }}>
+    <AvatarGroup max={4}>
+      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
+      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
+      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
+      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
+      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
+      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
+    </AvatarGroup>
+  </div>
+);
+
+export const Total: ComponentStory<typeof AvatarGroup> = () => (
+  <div style={{ display: 'flex', justifyContent: 'center' }}>
+    <AvatarGroup total={20}>
+      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
+      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
+      <Avatar src='https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg' />
+    </AvatarGroup>
+  </div>
+);

--- a/packages/web/src/components/ui/AvatarGroup/AvatarGroup.tsx
+++ b/packages/web/src/components/ui/AvatarGroup/AvatarGroup.tsx
@@ -4,25 +4,18 @@ import Avatar from '../Avatar/Avatar';
 
 type Props = {
   max?: number;
-  total?: number;
   children: React.ReactNode;
 };
 
-const AvatarGroup = ({ max = 5, total, children: childrenProp }: Props) => {
+const AvatarGroup = ({ max = 4, children: childrenProp }: Props) => {
   const children = React.Children.toArray(childrenProp).filter((child) =>
     React.isValidElement(child)
   );
 
-  let clampedMax = max < 2 ? 2 : max;
-  const totalAvatars = total ?? children.length;
+  const totalAvatars = children.length;
+  const clampedMax = Math.min(totalAvatars + 1, Math.max(max, 2));
 
-  if (totalAvatars === clampedMax) {
-    clampedMax += 1;
-  }
-
-  clampedMax = Math.min(totalAvatars + 1, clampedMax);
-
-  const maxAvatars = Math.min(children.length, clampedMax - 1);
+  const maxAvatars = Math.min(totalAvatars, clampedMax - 1);
   const extraAvatars = Math.max(totalAvatars - clampedMax, totalAvatars - maxAvatars, 0);
 
   return (

--- a/packages/web/src/components/ui/AvatarGroup/AvatarGroup.tsx
+++ b/packages/web/src/components/ui/AvatarGroup/AvatarGroup.tsx
@@ -1,10 +1,38 @@
 import React from 'react';
 import styles from './AvatarGroup.module.scss';
+import Avatar from '../Avatar/Avatar';
 
 type Props = {
+  max?: number;
+  total?: number;
   children: React.ReactNode;
 };
 
-const AvatarGroup = ({ children }: Props) => <div className={styles.avatars}>{children}</div>;
+const AvatarGroup = ({ max = 5, total, children: childrenProp }: Props) => {
+  const children = React.Children.toArray(childrenProp).filter((child) =>
+    React.isValidElement(child)
+  );
+
+  let clampedMax = max < 2 ? 2 : max;
+  const totalAvatars = total ?? children.length;
+
+  if (totalAvatars === clampedMax) {
+    clampedMax += 1;
+  }
+
+  clampedMax = Math.min(totalAvatars + 1, clampedMax);
+
+  const maxAvatars = Math.min(children.length, clampedMax - 1);
+  const extraAvatars = Math.max(totalAvatars - clampedMax, totalAvatars - maxAvatars, 0);
+
+  return (
+    <div className={styles.avatars}>
+      {extraAvatars ? <Avatar variant='additionalAvatars'>+{extraAvatars}</Avatar> : null}
+      {children
+        .slice(0, maxAvatars)
+        .map((child) => React.cloneElement(child as React.ReactElement))}
+    </div>
+  );
+};
 
 export default AvatarGroup;

--- a/packages/web/src/components/ui/PackagePreview/PackagePreview.module.scss
+++ b/packages/web/src/components/ui/PackagePreview/PackagePreview.module.scss
@@ -410,20 +410,5 @@
 }
 
 .authorImage {
-  flex-shrink: 0;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
   margin-left: 16px;
-
-  @include mobile-and-tablet {
-    width: 32px;
-    height: 32px;
-  }
-}
-
-.authorName {
-  @include mobile-and-tablet {
-    display: none;
-  }
 }

--- a/packages/web/src/components/ui/PackagePreview/PackagePreview.tsx
+++ b/packages/web/src/components/ui/PackagePreview/PackagePreview.tsx
@@ -304,14 +304,27 @@ export default function PackagePreview({
             )}
           </div>
 
-          <div className={styles.author}>
-            <AvatarGroup total={pkg.registryMetadata?.maintainers?.length}>
-              {(pkg.registryMetadata?.maintainers?.length ?? 0) > 0 &&
-                pkg.registryMetadata?.maintainers?.map((author) => (
-                  <Avatar alt={author.name} altAsTooltip={true} src={author.avatar} />
-                ))}
-            </AvatarGroup>
-          </div>
+          {(pkg.registryMetadata?.maintainers?.length ?? 0) > 0 && (
+            <div className={styles.author}>
+              {pkg.registryMetadata?.maintainers?.length === 1 ? (
+                <>
+                  <span>{pkg.registryMetadata.maintainers[0].name}</span>
+                  <span className={styles.authorImage}>
+                    <Avatar
+                      alt={pkg.registryMetadata.maintainers[0].name}
+                      src={pkg.registryMetadata.maintainers[0].avatar}
+                    />
+                  </span>
+                </>
+              ) : (
+                <AvatarGroup>
+                  {pkg.registryMetadata?.maintainers?.map((author) => (
+                    <Avatar alt={author.name} altAsTooltip={true} src={author.avatar} />
+                  ))}
+                </AvatarGroup>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/packages/web/src/components/ui/PackagePreview/PackagePreview.tsx
+++ b/packages/web/src/components/ui/PackagePreview/PackagePreview.tsx
@@ -305,7 +305,7 @@ export default function PackagePreview({
           </div>
 
           <div className={styles.author}>
-            <AvatarGroup>
+            <AvatarGroup total={pkg.registryMetadata?.maintainers?.length}>
               {(pkg.registryMetadata?.maintainers?.length ?? 0) > 0 &&
                 pkg.registryMetadata?.maintainers?.map((author) => (
                   <Avatar alt={author.name} altAsTooltip={true} src={author.avatar} />


### PR DESCRIPTION
- show rest elements as extra avatar with number of items beyond current maximum (default `max = 5`)
- slightly increase avatar size for small desktop (to 36px from 32px)

Before:
![before-1](https://user-images.githubusercontent.com/2999208/193615881-6ce984de-297c-4265-ae38-44f8cbbe3376.png)

After:
![after-1](https://user-images.githubusercontent.com/2999208/193615893-93474666-d920-4382-8d46-30dbbde7f68b.png)
