### PR TITLE
fix: add text overflow to chip text

### DIFF
--- a/packages/web/src/components/ui/Card/PackagesBySourceCard.tsx
+++ b/packages/web/src/components/ui/Card/PackagesBySourceCard.tsx
@@ -23,7 +23,7 @@ const PackagesBySourceCard = ({
     <div className={styles.tagsWrapper}>
       <ChipGroup>
         {packages.map((chip) => (
-          <Chip key={chip} className={styles.chip} size='large' font='monospace'>
+          <Chip key={chip} title={chip} className={styles.chip} size='large' font='monospace'>
             {chip}
           </Chip>
         ))}

--- a/packages/web/src/components/ui/Chip/Chip.module.scss
+++ b/packages/web/src/components/ui/Chip/Chip.module.scss
@@ -2,6 +2,7 @@
 @import '~styles/responsive.scss';
 
 .chip {
+  max-width: 100%;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -132,4 +133,10 @@
 .smallFont {
   font-size: 14px;
   line-height: 20px;
+}
+
+.text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/packages/web/src/components/ui/Chip/Chip.stories.tsx
+++ b/packages/web/src/components/ui/Chip/Chip.stories.tsx
@@ -14,16 +14,19 @@ const Template: ComponentStory<typeof Chip> = (args) => <Chip {...args}>{args.ch
 export const Regular = Template.bind({});
 Regular.args = {
   children: 'react',
+  title: 'react',
 };
 
 export const Medium = Template.bind({});
 Medium.args = {
   children: 'react',
+  title: 'react',
   size: 'medium',
 };
 
 export const Large = Template.bind({});
 Large.args = {
   children: 'react',
+  title: 'react',
   size: 'large',
 };

--- a/packages/web/src/components/ui/Chip/Chip.tsx
+++ b/packages/web/src/components/ui/Chip/Chip.tsx
@@ -20,6 +20,7 @@ export type ChipProps = {
   fontWeight?: 'normal' | 'semiBold';
   fontSize?: 'small' | 'regular';
   icon?: React.ReactElement<IconProps>;
+  title?: string;
   onClick?: React.MouseEventHandler<HTMLSpanElement>;
 };
 
@@ -32,6 +33,7 @@ export default function Chip({
   fontWeight = 'normal',
   fontSize = 'regular',
   icon,
+  title,
   onClick,
 }: ChipProps) {
   return (
@@ -45,10 +47,11 @@ export default function Chip({
         fontSize === 'small' && styles.smallFont,
         className
       )}
+      title={title}
       onClick={onClick}
     >
-      <span className={styles.icon}>{icon}</span>
-      {children}
+      {icon && <span className={styles.icon}>{icon}</span>}
+      <span className={styles.text}>{children}</span>
     </span>
   );
 }

--- a/packages/web/src/components/ui/ChipGroup/ChipGroup.stories.tsx
+++ b/packages/web/src/components/ui/ChipGroup/ChipGroup.stories.tsx
@@ -13,16 +13,18 @@ export default {
 
 export const Default: ComponentStory<typeof ChipGroup> = () => (
   <ChipGroup>
-    {['mdast-util-from-markdown', 'react', 'react-dom'].map((chip) => (
-      <Chip key={chip}>{chip}</Chip>
+    {['@reflectivechimp/gatsby-remark-normalize-paths', 'react', 'react-dom'].map((chip) => (
+      <Chip key={chip} title={chip}>
+        {chip}
+      </Chip>
     ))}
   </ChipGroup>
 );
 
 export const Medium: ComponentStory<typeof ChipGroup> = () => (
   <ChipGroup>
-    {['mdast-util-from-markdown', 'react', 'react-dom'].map((chip) => (
-      <Chip key={chip} size='medium' font='monospace'>
+    {['@reflectivechimp/gatsby-remark-normalize-paths', 'react', 'react-dom'].map((chip) => (
+      <Chip key={chip} title={chip} size='medium' font='monospace'>
         {chip}
       </Chip>
     ))}
@@ -31,8 +33,8 @@ export const Medium: ComponentStory<typeof ChipGroup> = () => (
 
 export const Large: ComponentStory<typeof ChipGroup> = () => (
   <ChipGroup>
-    {['mdast-util-from-markdown', 'react', 'react-dom'].map((chip) => (
-      <Chip key={chip} size='large' font='monospace'>
+    {['@reflectivechimp/gatsby-remark-normalize-paths', 'react', 'react-dom'].map((chip) => (
+      <Chip key={chip} title={chip} size='large' font='monospace'>
         {chip}
       </Chip>
     ))}

--- a/packages/web/src/components/ui/Hero/Hero.tsx
+++ b/packages/web/src/components/ui/Hero/Hero.tsx
@@ -65,8 +65,8 @@ export default function Hero({ suggestions, onSubmit = () => {}, loading = false
           {suggestions && (
             <div className={styles.suggestions}>
               {suggestions.map((suggestion) => (
-                <Link to={`/scan/${suggestion}`}>
-                  <Chip key={suggestion} variant='suggest' size='medium'>
+                <Link key={suggestion} to={`/scan/${suggestion}`}>
+                  <Chip title={suggestion} variant='suggest' size='medium'>
                     {suggestion}
                   </Chip>
                 </Link>

--- a/packages/web/src/components/ui/KeywordsList/KeywordsList.tsx
+++ b/packages/web/src/components/ui/KeywordsList/KeywordsList.tsx
@@ -24,6 +24,7 @@ export default function KeywordsList({ keywordsList, selectedKeywords, selectHan
       {displayedKeywords.map((keyword) => (
         <Chip
           key={keyword}
+          title={keyword}
           className={clsx(selectedKeywords.includes(keyword) && styles.sidebarChipActive)}
           onClick={() =>
             selectHandler(

--- a/packages/web/src/components/ui/PackagePreview/PackagePreview.module.scss
+++ b/packages/web/src/components/ui/PackagePreview/PackagePreview.module.scss
@@ -227,7 +227,7 @@
 
 .statList {
   display: grid;
-  grid-template-columns: 1fr 1fr 2fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr);
   grid-gap: 32px 20px;
 
   @include mobile-and-tablet {

--- a/packages/web/src/components/ui/PackagePreview/PackagePreview.tsx
+++ b/packages/web/src/components/ui/PackagePreview/PackagePreview.tsx
@@ -201,7 +201,13 @@ export default function PackagePreview({
                     ) : (
                       <ChipGroup>
                         {deps.map((dependency) => (
-                          <Chip size='medium' fontSize='small' font='monospace'>
+                          <Chip
+                            key={dependency}
+                            title={dependency}
+                            size='medium'
+                            fontSize='small'
+                            font='monospace'
+                          >
                             {dependency}
                           </Chip>
                         ))}

--- a/packages/web/src/components/ui/SearchResultsSidebar/SearchResultsSidebar.module.scss
+++ b/packages/web/src/components/ui/SearchResultsSidebar/SearchResultsSidebar.module.scss
@@ -4,6 +4,7 @@
 .sidebar {
   display: grid;
   grid-gap: 24px;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .sidebarItem {


### PR DESCRIPTION
- add text overflow to chip text with max-width
- render icon span only if icon is present
- pass optional title for accessibility
- add few missing keys

Before:
![image](https://user-images.githubusercontent.com/2999208/193868048-7b6ef05b-e9ed-482e-b063-73371a7f346e.png)

After:
![image](https://user-images.githubusercontent.com/2999208/193868152-a195427e-617e-40b3-9b08-40d45cf7651c.png)
