### PR TITLE
fix: sidebar mobile filter skeleton styles

### DIFF
--- a/packages/web/src/components/ui/SidebarMobileFilter/SidebarMobileFilterSkeleton.tsx
+++ b/packages/web/src/components/ui/SidebarMobileFilter/SidebarMobileFilterSkeleton.tsx
@@ -1,7 +1,7 @@
-import styles from '../../layouts/SearchResults/SearchResults.module.scss';
-import Skeleton from '../Skeleton/Skeleton';
-import { repeat } from '../../../utils/helpers';
 import React from 'react';
+import styles from './SidebarMobileFilter.module.scss';
+import Skeleton from '../Skeleton/Skeleton';
+import { repeat } from 'utils/helpers';
 
 export const SidebarMobileFilterSkeleton = () => (
   <>


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/2999208/194805967-f298b5f2-939c-4cff-b01f-d958658f69d9.png)

After:
![after](https://user-images.githubusercontent.com/2999208/194805972-2dd30949-9e68-4b8a-92b2-086150786b4f.png)
