### PR TITLE
fix: add missing selectedFilters dependency to mobileFilterTriggers

### DIFF
--- a/packages/web/src/components/ui/SearchResultsSidebar/SearchResultsSidebar.tsx
+++ b/packages/web/src/components/ui/SearchResultsSidebar/SearchResultsSidebar.tsx
@@ -66,7 +66,7 @@ export default function SearchResultsSidebar({
         onOpen: () => setActiveModal('authors'),
       },
     ],
-    []
+    [selectedFilters]
   );
 
   const handleFilterReset = useCallback(() => onFiltersChanged(null), [onFiltersChanged]);


### PR DESCRIPTION
So it can show selected counters inside mobile buttons after updates properly.

Before (at least one filter was selected, but counters did not update): 
![image](https://user-images.githubusercontent.com/2999208/194808242-af0b0863-06ae-4394-be2c-4fbe3f33ab72.png)

After:
![image](https://user-images.githubusercontent.com/2999208/194808087-932c4fad-4843-4778-8dfc-931d580cb404.png)
